### PR TITLE
Remove `--endpoint-url` flag on CLI calls

### DIFF
--- a/examples/apps/colorapp/servicemesh/delete.sh
+++ b/examples/apps/colorapp/servicemesh/delete.sh
@@ -32,16 +32,12 @@ sanity_check() {
     if [ -z ${MESH_NAME} ]; then
         err "MESH_NAME is not set"
     fi
-
-    if [ -z ${APPMESH_FRONTEND} ]; then
-        err "APPMESH_FRONTEND is not set"
-    fi
 }
 
 delete_route() {
     route_name=$1
     virtual_router_name=$2
-    aws --endpoint-url ${APPMESH_FRONTEND} appmesh delete-route \
+    aws appmesh delete-route \
         --mesh-name ${MESH_NAME} \
         --virtual-router-name ${virtual_router_name} \
         --route-name ${route_name} || print "Unable to delete route $route_name under virtual-router $virtual_router_name" "$?"
@@ -50,7 +46,7 @@ delete_route() {
 delete_virtual_router() {
     virtual_router_name=$1
     print "Deleting virtual-router ${virtual_router_name}"
-    aws --endpoint-url ${APPMESH_FRONTEND} appmesh delete-virtual-router \
+    aws appmesh delete-virtual-router \
         --mesh-name ${MESH_NAME} \
         --virtual-router-name ${virtual_router_name} || print "Unable to delete virtual-router $virtual_router_name" "$?"
 }
@@ -58,14 +54,14 @@ delete_virtual_router() {
 delete_virtual_node() {
     virtual_node_name=$1
     print "Deleting virutal-node ${virtual_node_name}"
-    aws --endpoint-url ${APPMESH_FRONTEND} appmesh delete-virtual-node \
+    aws appmesh delete-virtual-node \
         --mesh-name ${MESH_NAME} \
         --virtual-node-name ${virtual_node_name} || print "Unable to delete virtual-node $virtual_node_name" "$?"
 }
 
 main() {
     sanity_check
-   
+
     #delete routes
     for f in $(ls "${DIR}/config/routes/")
     do

--- a/examples/apps/colorapp/servicemesh/deploy.sh
+++ b/examples/apps/colorapp/servicemesh/deploy.sh
@@ -33,15 +33,11 @@ sanity_check() {
     if [ -z ${MESH_NAME} ]; then
         err "MESH_NAME is not set"
     fi
-
-    if [ -z ${APPMESH_FRONTEND} ]; then
-        err "APPMESH_FRONTEND is not set"
-    fi
 }
 
 update_virtual_node() {
     cli_input=$1
-    cmd=( aws --endpoint-url ${APPMESH_FRONTEND} appmesh update-virtual-node \
+    cmd=( aws appmesh update-virtual-node \
               --mesh-name ${MESH_NAME} \
               --cli-input-json "${cli_input}" \
               --query virtualNode.metadata.uid --output text )
@@ -52,7 +48,7 @@ update_virtual_node() {
 
 create_virtual_node() {
     cli_input=$1
-    cmd=( aws --endpoint-url ${APPMESH_FRONTEND} appmesh create-virtual-node \
+    cmd=( aws appmesh create-virtual-node \
               --mesh-name ${MESH_NAME} \
               --cli-input-json "${cli_input}" \
               --query virtualNode.metadata.uid --output text )
@@ -73,7 +69,7 @@ save_virtual_nodes() {
 
 create_virtual_router() {
     cli_input=$1
-    cmd=( aws --endpoint-url ${APPMESH_FRONTEND} appmesh create-virtual-router \
+    cmd=( aws appmesh create-virtual-router \
               --mesh-name ${MESH_NAME} \
               --cli-input-json "${cli_input}" \
               --query virtualRouter.metadata.uid --output text )
@@ -84,7 +80,7 @@ create_virtual_router() {
 
 update_virtual_router() {
     cli_input=$1
-    cmd=( aws --endpoint-url ${APPMESH_FRONTEND} appmesh update-virtual-router \
+    cmd=( aws appmesh update-virtual-router \
               --mesh-name ${MESH_NAME} \
               --cli-input-json "${cli_input}" \
               --query virtualRouter.metadata.uid --output text )
@@ -104,7 +100,7 @@ save_virtual_routers() {
 
 create_route() {
     cli_input=$1
-    cmd=( aws --endpoint-url ${APPMESH_FRONTEND} appmesh create-route \
+    cmd=( aws appmesh create-route \
               --mesh-name ${MESH_NAME} \
               --cli-input-json "${cli_input}" \
               --query route.metadata.uid --output text )
@@ -115,7 +111,7 @@ create_route() {
 
 update_route() {
     cli_input=$1
-    cmd=( aws --endpoint-url ${APPMESH_FRONTEND} appmesh update-route \
+    cmd=( aws appmesh update-route \
               --mesh-name ${MESH_NAME} \
               --cli-input-json "${cli_input}" \
               --query route.metadata.uid --output text )

--- a/examples/apps/colorapp/servicemesh/route_canary.sh
+++ b/examples/apps/colorapp/servicemesh/route_canary.sh
@@ -38,15 +38,11 @@ sanity_check() {
     if [ -z ${MESH_NAME} ]; then
         err "MESH_NAME is not set"
     fi
-
-    if [ -z ${APPMESH_FRONTEND} ]; then
-        err "APPMESH_FRONTEND is not set"
-    fi
 }
 
 update_route() {
     route_spec_file=$1
-    cmd=( aws --endpoint-url ${APPMESH_FRONTEND} appmesh update-route --mesh-name ${MESH_NAME} \
+    cmd=( aws appmesh update-route --mesh-name ${MESH_NAME} \
                 #--client-token "${service}-${RANDOM}" \
                 --cli-input-json file:///${route_spec_file} \
                 --query route.metadata.uid --output text )

--- a/examples/infrastructure/mesh.sh
+++ b/examples/infrastructure/mesh.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-aws --endpoint-url ${APPMESH_FRONTEND} appmesh create-mesh --mesh-name ${MESH_NAME}
+aws appmesh create-mesh --mesh-name ${MESH_NAME}


### PR DESCRIPTION
*Description of changes:*

Removes the `--endpoint-url` flag from App Mesh CLI calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
