### PR TITLE
Fixing region check fails for bash 3.2(which is default on mac OS)

### DIFF
--- a/examples/apps/colorapp/servicemesh/.region-config.sh
+++ b/examples/apps/colorapp/servicemesh/.region-config.sh
@@ -1,8 +1,3 @@
-declare -A SUPPORTED_REGIONS
-
-SUPPORTED_REGIONS[eu-west-1]=true
-SUPPORTED_REGIONS[us-east-1]=true
-SUPPORTED_REGIONS[us-east-2]=true
-SUPPORTED_REGIONS[us-west-2]=true
+SUPPORTED_REGIONS=(eu-west-1 us-east-1 us-east-2 us-west-2)
 
 DEFAULT_REGION=us-west-2

--- a/examples/apps/colorapp/servicemesh/deploy.sh
+++ b/examples/apps/colorapp/servicemesh/deploy.sh
@@ -25,9 +25,16 @@ err() {
     exit ${code}
 }
 
+contains() {
+    local e match="$1"
+    shift
+    for e; do [[ "$e" == "$match" ]] && return 0; done
+    return 1
+}
+
 sanity_check() {
-    if [ ! -n "${SUPPORTED_REGIONS[$AWS_DEFAULT_REGION]}" ]; then
-        err "Region ${AWS_DEFAULT_REGION} is not supported at this time (Supported regions: ${!SUPPORTED_REGIONS[*]})"
+    if ! contains "${AWS_DEFAULT_REGION}" "${SUPPORTED_REGIONS[@]}"; then
+        err "Region ${AWS_DEFAULT_REGION} is not supported at this time (Supported regions: ${SUPPORTED_REGIONS[*]})"
     fi
 
     if [ -z ${MESH_NAME} ]; then


### PR DESCRIPTION
*Issue #, if available:*
Mac OS uses bash3.2 by default which doesn't support Associative arrays.
Which leads to ambiguous error message:
```
⇒  ./servicemesh/deploy.sh
/Users/yathig/Downloads/aws-app-mesh-examples/examples/apps/colorapp/servicemesh/.region-config.sh: line 1: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
/Users/yathig/Downloads/aws-app-mesh-examples/examples/apps/colorapp/servicemesh/.region-config.sh: line 3: SUPPORTED_REGIONS[eu-west-1]: bad array subscript
/Users/yathig/Downloads/aws-app-mesh-examples/examples/apps/colorapp/servicemesh/.region-config.sh: line 4: SUPPORTED_REGIONS[us-east-1]: bad array subscript
/Users/yathig/Downloads/aws-app-mesh-examples/examples/apps/colorapp/servicemesh/.region-config.sh: line 5: SUPPORTED_REGIONS[us-east-2]: bad array subscript
/Users/yathig/Downloads/aws-app-mesh-examples/examples/apps/colorapp/servicemesh/.region-config.sh: line 6: SUPPORTED_REGIONS[us-west-2]: bad array subscript
./servicemesh/deploy.sh: line 29: SUPPORTED_REGIONS: bad array subscript
[MESH] [Thu Nov 29 14:44:20 PST 2018] : Error: Region eu-west-1 is not supported at this time (Supported regions: )
```

*Description of changes:*
This change removes Associative array and uses array for `SUPPORTED_REGIONS`
And checks if the `AWS_DEFAULT_REGION` exists in `SUPPORTED_REGIONS`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
