### PR TITLE
Using cloudformation deploy instead of create/update stack

### DIFF
--- a/examples/apps/colorapp/ecs/ecs-colorapp.sh
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.sh
@@ -2,18 +2,17 @@
 
 set -ex 
 
-ACTION="${1:-"create-stack"}"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 aws --profile "${AWS_PROFILE}" --region "${AWS_REGION}" \
-    cloudformation "${ACTION}" \
+    cloudformation deploy \
     --stack-name "${ENVIRONMENT_NAME}-ecs-colorapp" \
     --capabilities CAPABILITY_IAM \
-    --template-body "file://${DIR}/ecs-colorapp.yaml"  \
-    --parameters \
-    ParameterKey=EnvironmentName,ParameterValue="${ENVIRONMENT_NAME}" \
-    ParameterKey=EnvoyImage,ParameterValue="${ENVOY_IMAGE}" \
-    ParameterKey=ECSServicesDomain,ParameterValue="${SERVICES_DOMAIN}" \
-    ParameterKey=AppMeshMeshName,ParameterValue="${MESH_NAME}" \
-    ParameterKey=ColorGatewayImage,ParameterValue="${COLOR_GATEWAY_IMAGE}" \
-    ParameterKey=ColorTellerImage,ParameterValue="${COLOR_TELLER_IMAGE}"
+    --template-file "${DIR}/ecs-colorapp.yaml"  \
+    --parameter-overrides \
+    EnvironmentName="${ENVIRONMENT_NAME}" \
+    EnvoyImage="${ENVOY_IMAGE}" \
+    ECSServicesDomain="${SERVICES_DOMAIN}" \
+    AppMeshMeshName="${MESH_NAME}" \
+    ColorGatewayImage="${COLOR_GATEWAY_IMAGE}" \
+    ColorTellerImage="${COLOR_TELLER_IMAGE}"

--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -621,7 +621,7 @@ Resources:
             - Name: "LOOP"
               Value: "5"
             - Name: "DEBUG"
-              Value: "1"
+              Value: "0"
           Command:
             - !Sub "http://colorgateway.${ECSServicesDomain}:9080/color"
           LogConfiguration:

--- a/examples/infrastructure/ecs-cluster.sh
+++ b/examples/infrastructure/ecs-cluster.sh
@@ -2,16 +2,15 @@
 
 set -ex 
 
-ACTION=${1:-"create-stack"}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-aws --profile ${AWS_PROFILE} --region ${AWS_REGION} \
-    cloudformation ${ACTION} \
-    --stack-name ${ENVIRONMENT_NAME}-ecs-cluster \
+aws --profile "${AWS_PROFILE}" --region "${AWS_REGION}" \
+    cloudformation deploy \
+    --stack-name "${ENVIRONMENT_NAME}-ecs-cluster" \
     --capabilities CAPABILITY_IAM \
-    --template-body file://${DIR}/ecs-cluster.yaml  \
-    --parameters \
-    ParameterKey=EnvironmentName,ParameterValue=${ENVIRONMENT_NAME} \
-    ParameterKey=KeyName,ParameterValue=${KEY_PAIR_NAME} \
-    ParameterKey=ECSServicesDomain,ParameterValue=${SERVICES_DOMAIN} \
-    ParameterKey=ClusterSize,ParameterValue=${CLUSTER_SIZE:-5} 
+    --template-file "${DIR}/ecs-cluster.yaml"  \
+    --parameter-overrides \
+    EnvironmentName="${ENVIRONMENT_NAME}" \
+    KeyName="${KEY_PAIR_NAME}" \
+    ECSServicesDomain="${SERVICES_DOMAIN}" \
+    ClusterSize="${CLUSTER_SIZE:-5}"

--- a/examples/infrastructure/eks-cluster.sh
+++ b/examples/infrastructure/eks-cluster.sh
@@ -2,14 +2,13 @@
 
 set -ex 
 
-ACTION=${1:-"create-stack"}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-aws --profile ${AWS_PROFILE} --region ${AWS_REGION} \
-    cloudformation ${ACTION} \
-    --stack-name ${ENVIRONMENT_NAME}-eks-cluster \
+aws --profile "${AWS_PROFILE}" --region "${AWS_REGION}" \
+    cloudformation deploy \
+    --stack-name "${ENVIRONMENT_NAME}-eks-cluster" \
     --capabilities CAPABILITY_IAM \
-    --template-body file://${DIR}/eks-cluster.yaml  \
-    --parameters \
-    ParameterKey=EnvironmentName,ParameterValue=${ENVIRONMENT_NAME} \
-    ParameterKey=KeyName,ParameterValue=${KEY_PAIR_NAME}
+    --template-file "${DIR}/eks-cluster.yaml"  \
+    --parameter-overrides \
+    EnvironmentName="${ENVIRONMENT_NAME}" \
+    KeyName="${KEY_PAIR_NAME}"

--- a/examples/infrastructure/vpc.sh
+++ b/examples/infrastructure/vpc.sh
@@ -2,13 +2,12 @@
 
 set -ex
 
-ACTION="${1:-"create-stack"}"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 aws --profile "${AWS_PROFILE}" --region "${AWS_REGION}" \
-    cloudformation "${ACTION}" \
+    cloudformation deploy \
     --stack-name "${ENVIRONMENT_NAME}-vpc" \
     --capabilities CAPABILITY_IAM \
-    --template-body "file://${DIR}/vpc.yaml" \
-    --parameters \
-    ParameterKey=EnvironmentName,ParameterValue="${ENVIRONMENT_NAME}"
+    --template-file "${DIR}/vpc.yaml" \
+    --parameter-overrides \
+    EnvironmentName="${ENVIRONMENT_NAME}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Using cloudformation deploy instead of create/update stack

- no need to switch between (create/update)-stack actions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
