### PR TITLE
Setup scripts: use AWS_PROFILE

### DIFF
--- a/examples/apps/colorapp/servicemesh/delete.sh
+++ b/examples/apps/colorapp/servicemesh/delete.sh
@@ -9,6 +9,10 @@ source $DIR/.region-config.sh
 
 : ${AWS_DEFAULT_REGION:=$DEFAULT_REGION}
 
+if [ ! -z "$AWS_PROFILE" ]; then
+    PROFILE_OPT="--profile ${AWS_PROFILE}"
+fi
+
 print() {
     printf "[MESH] [$(date)] : %s\n" "$*"
 }
@@ -45,6 +49,7 @@ delete_route() {
     route_name=$1
     virtual_router_name=$2
     aws appmesh delete-route \
+        ${PROFILE_OPT} \
         --mesh-name ${MESH_NAME} \
         --virtual-router-name ${virtual_router_name} \
         --route-name ${route_name} || print "Unable to delete route $route_name under virtual-router $virtual_router_name" "$?"
@@ -54,6 +59,7 @@ delete_virtual_router() {
     virtual_router_name=$1
     print "Deleting virtual-router ${virtual_router_name}"
     aws appmesh delete-virtual-router \
+        ${PROFILE_OPT} \
         --mesh-name ${MESH_NAME} \
         --virtual-router-name ${virtual_router_name} || print "Unable to delete virtual-router $virtual_router_name" "$?"
 }
@@ -62,6 +68,7 @@ delete_virtual_node() {
     virtual_node_name=$1
     print "Deleting virutal-node ${virtual_node_name}"
     aws appmesh delete-virtual-node \
+        ${PROFILE_OPT} \
         --mesh-name ${MESH_NAME} \
         --virtual-node-name ${virtual_node_name} || print "Unable to delete virtual-node $virtual_node_name" "$?"
 }

--- a/examples/apps/colorapp/servicemesh/deploy.sh
+++ b/examples/apps/colorapp/servicemesh/deploy.sh
@@ -8,6 +8,10 @@ if [ -f meshvars.sh ]; then
     source meshvars.sh
 fi
 
+if [ ! -z "$AWS_PROFILE" ]; then
+    PROFILE_OPT="--profile ${AWS_PROFILE}"
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 source $DIR/.region-config.sh
@@ -45,6 +49,7 @@ sanity_check() {
 update_virtual_node() {
     cli_input=$1
     cmd=( aws appmesh update-virtual-node \
+              ${PROFILE_OPT} \
               --mesh-name "${MESH_NAME}" \
               --cli-input-json "${cli_input}" \
               --query virtualNode.metadata.uid --output text )
@@ -56,6 +61,7 @@ update_virtual_node() {
 create_virtual_node() {
     cli_input=$1
     cmd=( aws appmesh create-virtual-node \
+              ${PROFILE_OPT} \
               --mesh-name "${MESH_NAME}" \
               --cli-input-json "${cli_input}" \
               --query virtualNode.metadata.uid --output text )
@@ -77,6 +83,7 @@ save_virtual_nodes() {
 create_virtual_router() {
     cli_input=$1
     cmd=( aws appmesh create-virtual-router \
+              ${PROFILE_OPT} \
               --mesh-name "${MESH_NAME}" \
               --cli-input-json "${cli_input}" \
               --query virtualRouter.metadata.uid --output text )
@@ -88,6 +95,7 @@ create_virtual_router() {
 update_virtual_router() {
     cli_input=$1
     cmd=( aws appmesh update-virtual-router \
+              ${PROFILE_OPT} \
               --mesh-name "${MESH_NAME}" \
               --cli-input-json "${cli_input}" \
               --query virtualRouter.metadata.uid --output text )
@@ -108,6 +116,7 @@ save_virtual_routers() {
 create_route() {
     cli_input=$1
     cmd=( aws appmesh create-route \
+              ${PROFILE_OPT} \
               --mesh-name "${MESH_NAME}" \
               --cli-input-json "${cli_input}" \
               --query route.metadata.uid --output text )
@@ -119,6 +128,7 @@ create_route() {
 update_route() {
     cli_input=$1
     cmd=( aws appmesh update-route \
+              ${PROFILE_OPT} \
               --mesh-name "${MESH_NAME}" \
               --cli-input-json "${cli_input}" \
               --query route.metadata.uid --output text )

--- a/examples/apps/colorapp/servicemesh/route_canary.sh
+++ b/examples/apps/colorapp/servicemesh/route_canary.sh
@@ -8,6 +8,10 @@ if [ -f meshvars.sh ]; then
     source meshvars.sh
 fi
 
+if [ ! -z "$AWS_PROFILE" ]; then
+    PROFILE_OPT="--profile ${AWS_PROFILE}"
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 UPDATE_ROUTES_DIR="${DIR}/config/update_routes/"
 
@@ -46,6 +50,7 @@ sanity_check() {
 update_route() {
     route_spec_file=$1
     cmd=( aws appmesh update-route --mesh-name "${MESH_NAME}" \
+                ${PROFILE_OPT} \
                 --cli-input-json "file:///${route_spec_file}" \
                 --query route.metadata.uid --output text )
     print "${cmd[@]}"

--- a/examples/infrastructure/mesh.sh
+++ b/examples/infrastructure/mesh.sh
@@ -2,4 +2,8 @@
 
 set -ex
 
-aws appmesh create-mesh --mesh-name "${MESH_NAME}"
+if [ ! -z "${AWS_PROFILE}" ]; then
+    PROFILE_OPT="--profile ${AWS_PROFILE}"
+fi
+
+aws ${PROFILE_OPT} appmesh create-mesh --mesh-name "${MESH_NAME}"


### PR DESCRIPTION
*Description of changes:*
The AWS_PROFILE field isn't used in two of the setup scripts for the ECS demo. This change causes the scripts to observe the profile field, but only if it is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
