### PR TITLE
Add health check example to colorapp

### DIFF
--- a/examples/apps/colorapp/servicemesh/config/virtualnodes/colorteller-black-virtualnode.json
+++ b/examples/apps/colorapp/servicemesh/config/virtualnodes/colorteller-black-virtualnode.json
@@ -5,6 +5,14 @@
                 "portMapping": {
                     "port": 9080,
                     "protocol": "http"
+                },
+                "healthCheck": {
+                    "protocol": "http",
+                    "path": "/ping",
+                    "healthyThreshold": 2,
+                    "unhealthyThreshold": 2,
+                    "timeoutMillis": 2000,
+                    "intervalMillis": 5000
                 }
             }
         ],

--- a/examples/apps/colorapp/servicemesh/config/virtualnodes/colorteller-blue-virtualnode.json
+++ b/examples/apps/colorapp/servicemesh/config/virtualnodes/colorteller-blue-virtualnode.json
@@ -5,6 +5,14 @@
                 "portMapping": {
                     "port": 9080,
                     "protocol": "http"
+                },
+                "healthCheck": {
+                    "protocol": "http",
+                    "path": "/ping",
+                    "healthyThreshold": 2,
+                    "unhealthyThreshold": 2,
+                    "timeoutMillis": 2000,
+                    "intervalMillis": 5000
                 }
             }
         ],

--- a/examples/apps/colorapp/servicemesh/config/virtualnodes/colorteller-red-virtualnode.json
+++ b/examples/apps/colorapp/servicemesh/config/virtualnodes/colorteller-red-virtualnode.json
@@ -5,6 +5,14 @@
                 "portMapping": {
                     "port": 9080,
                     "protocol": "http"
+                },
+                "healthCheck": {
+                    "protocol": "http",
+                    "path": "/ping",
+                    "healthyThreshold": 2,
+                    "unhealthyThreshold": 2,
+                    "timeoutMillis": 2000,
+                    "intervalMillis": 5000
                 }
             }
         ],

--- a/examples/apps/colorapp/servicemesh/config/virtualnodes/colorteller-virtualnode.json
+++ b/examples/apps/colorapp/servicemesh/config/virtualnodes/colorteller-virtualnode.json
@@ -5,6 +5,14 @@
                 "portMapping": {
                     "port": 9080,
                     "protocol": "http"
+                },
+                "healthCheck": {
+                    "protocol": "http",
+                    "path": "/ping",
+                    "healthyThreshold": 2,
+                    "unhealthyThreshold": 2,
+                    "timeoutMillis": 2000,
+                    "intervalMillis": 5000
                 }
             }
         ],

--- a/examples/apps/colorapp/servicemesh/config/virtualnodes/tcpecho-virtualnode.json
+++ b/examples/apps/colorapp/servicemesh/config/virtualnodes/tcpecho-virtualnode.json
@@ -5,6 +5,13 @@
                 "portMapping": {
                     "port": 2701,
                     "protocol": "tcp"
+                },
+                "healthCheck": {
+                    "protocol": "tcp",
+                    "healthyThreshold": 2,
+                    "unhealthyThreshold": 2,
+                    "timeoutMillis": 2000,
+                    "intervalMillis": 5000
                 }
             }
         ],

--- a/examples/apps/colorapp/src/colorteller/main.go
+++ b/examples/apps/colorapp/src/colorteller/main.go
@@ -28,12 +28,19 @@ func getColor() string {
 	return defaultColor
 }
 
-func handler(writer http.ResponseWriter, request *http.Request) {
+func colorHandler(writer http.ResponseWriter, request *http.Request) {
+	log.Println("color requested, responding with", getColor())
 	fmt.Fprint(writer, getColor())
+}
+
+func pingHandler(writer http.ResponseWriter, request *http.Request) {
+	log.Println("ping requested, reponding with HTTP 200")
+	writer.WriteHeader(http.StatusOK)
 }
 
 func main() {
 	log.Println("starting server, listening on port " + getServerPort())
-	http.HandleFunc("/", handler)
+	http.HandleFunc("/", colorHandler)
+	http.HandleFunc("/ping", pingHandler)
 	http.ListenAndServe(":"+getServerPort(), nil)
 }


### PR DESCRIPTION
*Issue #, if available:* #19 

*Description of changes:*

Provides an example active health check configuration for TCP and HTTP backend VirtualNodes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
