### PR TITLE
Rename ColorTeller to ColorTellerWhite

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,8 +21,8 @@ export KEY_PAIR_NAME=<key-pair to access ec2 instances where apps are running>
 export ENVOY_IMAGE="111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.8.0.2-beta"
 export CLUSTER_SIZE=<number of ec2 instances to spin up to join cluster
 export SERVICES_DOMAIN=<domain under which services will be discovered, e.g. "default.svc.cluster.local">
-export COLOR_GATEWAY_IMAGE=<image location for colorapp's gateway, e.g. "123.dkr.ecr.amazonaws.com/gateway:latest">
-export COLOR_TELLER_IMAGE=<image location for colorapp's teller, e.g. "123.dkr.ecr.amazonaws.com/colorteller:latest">
+export COLOR_GATEWAY_IMAGE=<image location for colorapp's gateway, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/gateway:latest" - you need to build this image and use your own ECR repository, see below>
+export COLOR_TELLER_IMAGE=<image location for colorapp's teller, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/colorteller:latest" - you need to build this image and use your own ECR repository, see below>
 ```
 
 ## Infrastructure
@@ -56,3 +56,19 @@ $ ./infrastructure/eks-cluster.sh create-stack
 Once infrastructure is in place you can deploy applications and configure mesh. Go to corresponding application directory under ***apps/*** and follow the directions, e.g. *apps/colorapp*.
 
 To add new app, create a directory under apps and follow the setup as in colorapp
+
+### Building Docker Images
+
+In Elastic Container Registry, created two new repositories:
+ - colorteller
+ - gateway
+
+Build the docker images as follow:
+```
+cd apps/colorapp/src/colorteller/
+./deploy.sh
+cd -
+cd apps/colorapp/src/gateway
+./deploy.sh
+cd -
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,8 +21,8 @@ export KEY_PAIR_NAME=<key-pair to access ec2 instances where apps are running>
 export ENVOY_IMAGE="111345817488.dkr.ecr.us-west-2.amazonaws.com/aws-appmesh-envoy:v1.8.0.2-beta"
 export CLUSTER_SIZE=<number of ec2 instances to spin up to join cluster
 export SERVICES_DOMAIN=<domain under which services will be discovered, e.g. "default.svc.cluster.local">
-export COLOR_GATEWAY_IMAGE=<image location for colorapp's gateway, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/gateway:latest" - you need to build this image and use your own ECR repository, see below>
-export COLOR_TELLER_IMAGE=<image location for colorapp's teller, e.g. "<youraccountnumber>.dkr.ecr.amazonaws.com/colorteller:latest" - you need to build this image and use your own ECR repository, see below>
+export COLOR_GATEWAY_IMAGE=<image location for colorapp's gateway, e.g. "123.dkr.ecr.amazonaws.com/gateway:latest">
+export COLOR_TELLER_IMAGE=<image location for colorapp's teller, e.g. "123.dkr.ecr.amazonaws.com/colorteller:latest">
 ```
 
 ## Infrastructure
@@ -56,19 +56,3 @@ $ ./infrastructure/eks-cluster.sh create-stack
 Once infrastructure is in place you can deploy applications and configure mesh. Go to corresponding application directory under ***apps/*** and follow the directions, e.g. *apps/colorapp*.
 
 To add new app, create a directory under apps and follow the setup as in colorapp
-
-### Building Docker Images
-
-In Elastic Container Registry, created two new repositories:
- - colorteller
- - gateway
-
-Build the docker images as follow:
-```
-cd apps/colorapp/src/colorteller/
-./deploy.sh
-cd -
-cd apps/colorapp/src/gateway
-./deploy.sh
-cd -
-```

--- a/examples/apps/colorapp/ecs/ecs-colorapp.yaml
+++ b/examples/apps/colorapp/ecs/ecs-colorapp.yaml
@@ -44,11 +44,11 @@ Parameters:
 
 Resources:
 
-  ### colorteller.default.svc.cluster.local
-  ColorTellerServiceDiscoveryRecord:
+  ### colorteller-white.default.svc.cluster.local
+  ColorTellerWhiteServiceDiscoveryRecord:
     Type: 'AWS::ServiceDiscovery::Service'
     Properties:
-      Name: "colorteller"
+      Name: "colorteller-white"
       DnsConfig:
         NamespaceId:
           'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceDiscoveryNamespace"
@@ -58,7 +58,7 @@ Resources:
       HealthCheckCustomConfig:
         FailureThreshold: 1
 
-  ColorTellerService:
+  ColorTellerWhiteService:
     Type: 'AWS::ECS::Service'
     Properties:
       Cluster:
@@ -70,7 +70,7 @@ Resources:
       LaunchType: EC2
       ServiceRegistries:
         - RegistryArn:
-            'Fn::GetAtt': ColorTellerServiceDiscoveryRecord.Arn
+            'Fn::GetAtt': ColorTellerWhiteServiceDiscoveryRecord.Arn
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -79,9 +79,9 @@ Resources:
           Subnets: 
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet1"
             - 'Fn::ImportValue': !Sub "${EnvironmentName}:PrivateSubnet2"
-      TaskDefinition: { Ref: ColorTellerTaskDefinition }
+      TaskDefinition: { Ref: ColorTellerWhiteTaskDefinition }
 
-  ColorTellerTaskDefinition:
+  ColorTellerWhiteTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
       ContainerDefinitions:
@@ -94,7 +94,7 @@ Resources:
               awslogs-group:
                 'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceLogGroup"
               awslogs-region: { Ref: "AWS::Region" }
-              awslogs-stream-prefix: "colorteller-app"
+              awslogs-stream-prefix: "colorteller-white-app"
           PortMappings:
             - ContainerPort: 9080
               HostPort: 9080
@@ -114,10 +114,10 @@ Resources:
               awslogs-group:
                 'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceLogGroup" 
               awslogs-region: { Ref: "AWS::Region" }
-              awslogs-stream-prefix: "colorteller-envoy"
+              awslogs-stream-prefix: "colorteller-white-envoy"
           Environment:
             - Name: "APPMESH_VIRTUAL_NODE_NAME"
-              Value: !Sub "mesh/${AppMeshMeshName}/virtualNode/colorteller-vn"
+              Value: !Sub "mesh/${AppMeshMeshName}/virtualNode/colorteller-white-vn"
             - Name: "ENVOY_LOG_LEVEL"
               Value: { Ref: EnvoyLogLevel }
             - Name: "APPMESH_XDS_ENDPOINT"
@@ -131,7 +131,7 @@ Resources:
               awslogs-group:
                 'Fn::ImportValue': !Sub "${EnvironmentName}:ECSServiceLogGroup"
               awslogs-region: { Ref: "AWS::Region" }
-              awslogs-stream-prefix: "colorteller-proxyinit"
+              awslogs-stream-prefix: "colorteller-white-proxyinit"
           LinuxParameters:
             Capabilities:
               Add:


### PR DESCRIPTION
Not sure why this Service & Task Def was named without a colour, it looks the same as the other ones. It gives the impression that it's perhaps an aggregation or something for the other ColorServices (to the uninitiated trying out this example). Maybe it was the original service and the other colours were added later. 

With this rename it looks a bit more consistent unless I missed something! 