### PR TITLE
Add --region and --profile option to ecr get-login command.

### DIFF
--- a/examples/apps/colorapp/src/colorteller/deploy.sh
+++ b/examples/apps/colorapp/src/colorteller/deploy.sh
@@ -12,5 +12,5 @@ fi
 docker build -t $COLOR_TELLER_IMAGE .
 
 # push
-$(aws ecr get-login --no-include-email)
+$(aws ecr get-login --no-include-email --region $AWS_REGION --profile $AWS_PROFILE)
 docker push $COLOR_TELLER_IMAGE

--- a/examples/apps/colorapp/src/gateway/deploy.sh
+++ b/examples/apps/colorapp/src/gateway/deploy.sh
@@ -12,5 +12,5 @@ fi
 docker build -t $COLOR_GATEWAY_IMAGE .
 
 # push
-$(aws ecr get-login --no-include-email)
+$(aws ecr get-login --no-include-email --region $AWS_REGION --profile $AWS_PROFILE)
 docker push $COLOR_GATEWAY_IMAGE


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Awscli command in infrastructure setup scripts refer environment variables `$AWS_REGION` and `$AWS_PROFILE`. But awscli command in `deploy.sh` does not refer them. So I fix it.