### PR TITLE
Updating EKS CFN template and READMEs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ Before we can start playing with mesh examples we need to setup infrastructure p
 * Setup VPC
 
 ```
-$ ./infrastructure/vpc.sh create-stack
+$ ./infrastructure/vpc.sh
 ```
 
 * Setup Mesh
@@ -43,13 +43,13 @@ $ ./infrastructure/mesh.sh
 * Setup ECS Cluster (Optional if using ECS)
 
 ```
-$ ./infrastructure/ecs-cluster.sh create-stack
+$ ./infrastructure/ecs-cluster.sh
 ```
 
 * Setup EKS Cluster (Optional if using EKS). Note that there are more steps to use Kubernetes cluster that are not covered here. Please follow [EKS Getting Started Guide](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
 ```
-$ ./infrastructure/eks-cluster.sh create-stack
+$ ./infrastructure/eks-cluster.sh
 ```
 
 ## Apps
@@ -57,7 +57,7 @@ Once infrastructure is in place you can deploy applications and configure mesh. 
 
 To add new app, create a directory under apps and follow the setup as in colorapp
 
-### Building Docker Images
+## Building Docker Images
 
 In Elastic Container Registry, created two new repositories:
  - colorteller

--- a/examples/apps/colorapp/README.md
+++ b/examples/apps/colorapp/README.md
@@ -10,7 +10,7 @@ $ curl -s http://colorgateway.default.svc.cluster.local:9080/color
 
 ... after many such calls ...
 $ curl -s http://colorgateway.default.svc.cluster.local:9080/color
-{"color":"blue", "stats": {"black":0.164119601328904,"blue":0.823920265780731,"red":0.011960132890366}}
+{"color":"blue", "stats": {"black":0.16,"blue":0.82,"red":0.01}}
 ```
 
 color-gateway app runs as a service in ECS, optionally exposed via external load-balancer (ALB). Each task in gateway is configured with the endpoint of color-teller service that it communicates with via Envoy that is configured by AWS App Mesh.

--- a/examples/infrastructure/eks-cluster.yaml
+++ b/examples/infrastructure/eks-cluster.yaml
@@ -199,6 +199,7 @@ Resources:
 
   NodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn: EKSCluster
     Properties:
       DesiredCapacity: !Ref NodeAutoScalingGroupMaxSize
       LaunchConfigurationName: !Ref NodeLaunchConfig
@@ -246,3 +247,6 @@ Resources:
                      --resource NodeGroup  \
                      --region ${AWS::Region}
 
+Outputs:
+  NodeInstanceRole:
+    Value: !GetAtt NodeInstanceRole.Arn


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

According to AWS EKS docs: 
```
"Wait for your cluster status to show as ACTIVE. If you launch your worker nodes before the cluster is active, the worker nodes will fail to register with the cluster and you will have to relaunch them."
```

1. Updated CFN template to handle the above case. 
2. Added `NodeInstanceRole` to CFN stack output so that it can be used for configmap update.
3. Minor changes in READMEs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.